### PR TITLE
curator: auto-skip factory:roadmap and factory:curator-proposals in intake

### DIFF
--- a/.loswf/config.yaml
+++ b/.loswf/config.yaml
@@ -61,7 +61,7 @@ standards:
 
 # Curator scoping — issues matching these are skipped by intake.
 curator:
-  ignore_labels: [question, wontfix, duplicate, dependencies, invalid]
+  ignore_labels: [question, wontfix, duplicate, dependencies, invalid, factory:roadmap, factory:curator-proposals]
   ignore_authors: ["dependabot[bot]", "renovate[bot]", "github-actions[bot]"]
   cadence_hours: 1
 


### PR DESCRIPTION
## Summary

- Adds `factory:roadmap` and `factory:curator-proposals` to `curator.ignore_labels` in `.loswf/config.yaml`
- Prevents intake from attempting to classify factory-internal tracker issues (#4, #5) as work items every sweep
- Companion to the safe-op factory:hold already applied to both issues

## Problem

Issues #4 (factory:roadmap) and #5 (factory:curator-proposals) carry no `factory:phase:*` label by design — they are perpetual trackers, not discrete work items. Without an ignore rule, intake picks them up on every sweep and tries to triage them into the pipeline.

## Change

```yaml
# before
ignore_labels: [question, wontfix, duplicate, dependencies, invalid]

# after
ignore_labels: [question, wontfix, duplicate, dependencies, invalid, factory:roadmap, factory:curator-proposals]
```

## Test plan

- [ ] Verify `gh issue list --label factory:roadmap` is skipped by the next intake sweep (no new phase labels added to #4 or #5)
- [ ] Confirm `factory:hold` on #4 and #5 remains as belt-and-suspenders guard
- [ ] Confirm no other open issues are incorrectly skipped by the new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)