### PR TITLE
docs: file prebuild-matrix, release-pipeline, typescript-surface specs (#8)

### DIFF
--- a/specs/SRS.md
+++ b/specs/SRS.md
@@ -32,7 +32,18 @@ Out of scope (see VISION non-goals):
 
 ## 3. Specs Index
 
-Individual specs will be filed under `specs/` as they are scoped out.
+Scoped capability specs live alongside this document:
+
+- [`prebuild-matrix.md`](./prebuild-matrix.md) — native-addon prebuild
+  pipeline, platform matrix, and install-time binding resolution
+  (VISION principles 2 & 3; SRS sections 2 and 5).
+- [`release-pipeline.md`](./release-pipeline.md) — version/tag/publish
+  plumbing, prebuild-artifact parity, and release guardrails
+  (VISION principle 7; SRS section 6).
+- [`typescript-surface.md`](./typescript-surface.md) — the public
+  JavaScript/TypeScript API contract, module shape, and typecheck
+  gate (VISION principle 1; SRS section 2).
+
 The current roadmap order is tracked in the `factory:roadmap` issue on
 GitHub. Drafts under `specs/drafts/` are curator proposals awaiting
 triage.

--- a/specs/drafts/8-missing-specs.md
+++ b/specs/drafts/8-missing-specs.md
@@ -1,0 +1,40 @@
+<!-- loswf:plan -->
+# Plan #8: File the missing `specs/` capability specs (prebuild-matrix, release-pipeline, typescript-surface)
+
+## Problem
+`specs/SRS.md` section 3 (lines 33-38) promises "Individual specs will be filed under `specs/` as they are scoped out," but `specs/` currently contains only `SRS.md`, `VISION.md`, and an empty `drafts/.gitkeep`. VISION's three core capability areas — the prebuild matrix (VISION principle 2; SRS section 5), the TypeScript public surface (VISION principle 1; SRS section 2), and the release pipeline (VISION principle 7; SRS section 6) — have no scoped spec files. Without them, factory agents have no per-capability acceptance criteria beyond the three base gates (`typecheck`, `test`, `verify-package`) defined in `.loswf/config.yaml` lines 34-40, and the `factory:roadmap` issue (#4) has nothing concrete to link to.
+
+## Approach
+This is a docs-only issue (label `factory:type:docs`). Draft three new spec files under `specs/` — one per in-scope capability — each following a consistent template: Scope, SRS/VISION anchors, Acceptance Criteria, Additional Validation Gates (if any), and Out-of-Scope. Each spec cites concrete file/line references in the repo (`package.json`, `scripts/*.js`, `src/index.ts`, `binding.gyp`, `.loswf/config.yaml`) so downstream builders have unambiguous targets. Update `specs/SRS.md` section 3 to list the new specs inline. Add a follow-up checklist to the `factory:roadmap` issue (#4) linking the three new specs. No code changes.
+
+## Files to touch
+- `specs/SRS.md` — replace the placeholder prose in section 3 (lines 33-38) with an actual index of the new specs; keep the drafts-directory note.
+
+## New files
+- `specs/prebuild-matrix.md` — scopes the platform prebuild pipeline (SRS section 5, VISION principle 2). Anchors: `scripts/prebuild.js`, `scripts/prebuild-linux-x64.js`, `scripts/prebuild-release.js`, `scripts/smoke-linux-x64.js`, `prebuilds/` layout, `binding.gyp`, `scripts/install.js`. Declares acceptance criteria for matrix coverage (linux x64/arm64 glibc, macOS x64/arm64, win x64) and proposes an optional `prebuild-smoke` validation gate.
+- `specs/release-pipeline.md` — scopes versioning, tagging, publish, and artifact attachment (SRS section 6, VISION principle 7). Anchors: `scripts/prebuild-release.js`, `scripts/verify-package.js`, `scripts/smoke-packed-package.js`, `package.json` `publish:local` script, repo guardrails (`.loswf/config.yaml` lines 46-51). Criteria include tagged-commit parity between prebuild artifacts and published tarball, prohibition on hook-bypass commits, no accidental version bumps.
+- `specs/typescript-surface.md` — scopes the public TS API contract (SRS section 2, VISION principle 1). Anchors: `src/index.ts`, `dist/index.d.ts`, `package.json` `exports` block (lines 8-14), `tsconfig.json`. Criteria include: all public functions typed, `tsc --noEmit` passes, CommonJS-only module shape preserved, breaking type changes require a release task.
+
+## Step-by-step
+1. Create `specs/prebuild-matrix.md` with the template above, referencing the concrete scripts and `binding.gyp`. Verifiable: file exists, cites `SRS.md` section 5 and `VISION.md` principle 2 by name, lists the five-platform matrix, declares 3 or more acceptance criteria.
+2. Create `specs/release-pipeline.md`. Verifiable: file exists, cites `SRS.md` section 6 and `VISION.md` principle 7, references `publish:local` in `package.json`, lists tagged-commit/prebuild-parity criterion.
+3. Create `specs/typescript-surface.md`. Verifiable: file exists, cites `SRS.md` section 2 and `VISION.md` principle 1, references `src/index.ts` and `dist/index.d.ts`, lists the `tsc --noEmit` gate and the CJS-only constraint.
+4. Edit `specs/SRS.md` section 3 to list the three new specs with relative links; preserve the `specs/drafts/` triage note. Verifiable: grep for the three spec filenames in `specs/SRS.md` returns three hits.
+5. Append a checklist to the `factory:roadmap` issue (#4) body (via `gh issue edit 4 --body-file ...` or a comment) linking the three new specs. Verifiable: `gh issue view 4` shows the three links.
+
+## Tests
+- Docs-only change; the three base gates still run but are no-ops for Markdown.
+- Ad-hoc verification: `ls specs/*.md` lists five files (SRS, VISION, three new specs). `rg -l "VISION principle|SRS section" specs/` hits each new spec.
+- No new `src/` files, so the "every src file has a test" guardrail does not trigger.
+
+## Validation
+- `tsc -p tsconfig.json --noEmit` (from `.loswf/config.yaml` validate[0]) — must still pass; no code touched.
+- `npm test` (validate[1]) — must still pass.
+- `npm run verify:package` (validate[2]) — must still pass; `specs/` is not in `package.json` `files`, so the tarball is unchanged.
+
+## Risks
+- Scope creep into typescript-surface spec. The current `src/index.ts` may already diverge from what the spec would demand; the spec must describe what should be true without being read as a demand to change code in this PR. Mitigation: explicit "Out of Scope: modifying current implementation" clause in that spec.
+- Roadmap update permission. Editing issue #4 body requires write access; if the bot token lacks it, fall back to a comment on #4 instead.
+- Duplication with SRS. The new specs must not restate SRS content verbatim; they must add per-capability acceptance criteria. Mitigation: each spec explicitly links to SRS sections rather than copying them.
+- Additional validation gates. The prebuild-matrix spec may propose a `prebuild-smoke` gate but wiring it into `.loswf/config.yaml` is out of scope for this docs issue — call it out as a follow-up.
+

--- a/specs/prebuild-matrix.md
+++ b/specs/prebuild-matrix.md
@@ -1,0 +1,95 @@
+# Spec — Prebuild Matrix
+
+## Scope
+
+This spec scopes the native-addon prebuild pipeline for `@xifty/xifty`:
+how platform-specific binaries are produced, laid out on disk, published
+with the npm tarball, and selected at install time. It does NOT scope
+the release-pipeline orchestration that drives these builds on a tagged
+commit (see [`release-pipeline.md`](./release-pipeline.md)) or the
+public TypeScript surface the binding is bound to
+(see [`typescript-surface.md`](./typescript-surface.md)).
+
+## Anchors
+
+- **SRS**: [`SRS.md`](./SRS.md) section 2 (addon packaging), section 5
+  (Platform Matrix), section 6 (Release Guardrails).
+- **VISION**: [`VISION.md`](./VISION.md) principle 2 ("Prebuilt binaries
+  are the happy path") and principle 3 ("Source builds are opt-in").
+- **Code**:
+  - `binding.gyp` — node-gyp target definition.
+  - `scripts/prebuild.js` — local single-host prebuild (`build:prebuilds:local`).
+  - `scripts/prebuild-linux-x64.js` — Linux x64 dockerized prebuild
+    (`build:prebuilds:linux-x64`).
+  - `scripts/prebuild-release.js` — full release matrix entry point
+    (`build:prebuilds`).
+  - `scripts/smoke-linux-x64.js` — linux-x64 packed-tarball smoke
+    (`verify:linux-x64`).
+  - `scripts/install.js` — install-time binding resolution; routes to
+    prebuild-first, source-build-on-opt-in.
+  - `scripts/build-addon.js` — source-build path invoked when
+    `XIFTY_BUILD_FROM_SOURCE=1`.
+  - `prebuilds/<platform>-<arch>/` — prebuildify layout consumed by
+    `node-gyp-build` at runtime.
+
+## Platform Matrix
+
+Per SRS section 5, the minimum target matrix is:
+
+- Linux x64 (glibc)
+- Linux arm64 (glibc)
+- macOS x64
+- macOS arm64
+- Windows x64
+
+Current release coverage (per `src/index.ts` install-error guidance) is
+macOS arm64 and Linux x64; the remaining platforms are tracked as
+roadmap gaps, not silent failures — the install error names each
+unsupported target explicitly. Any change to the matrix MUST update both
+`src/index.ts`'s unsupported-platform error message and this spec in
+the same PR.
+
+## Acceptance Criteria
+
+A change under this spec is acceptable when:
+
+1. **Matrix parity.** Every platform claimed by `src/index.ts` as
+   "supported" has a corresponding `prebuilds/<platform>-<arch>/` entry
+   produced by the release matrix script.
+2. **No silent source-build fallback.** `scripts/install.js` MUST NOT
+   invoke `node-gyp` unless `XIFTY_BUILD_FROM_SOURCE=1` is set in the
+   environment; a missing prebuild on an unsupported platform MUST
+   produce a clear error naming the unsupported target (the message
+   currently in `src/index.ts`).
+4. **Install-time resolution is prebuild-first.** `node-gyp-build`
+   resolves against `prebuilds/` before any compiler is touched.
+5. **Consumer-facing error text stays accurate.** If the matrix
+   changes, the unsupported-platform message in `src/index.ts`
+   (the string beginning "@xifty/xifty does not ship a native build…")
+   MUST be updated in the same change.
+
+## Additional Validation Gates
+
+In addition to the three base gates in `.loswf/config.yaml`
+(`typecheck`, `test`, `verify-package`):
+
+- `npm run verify:linux-x64` — runs `scripts/smoke-linux-x64.js`
+  against the packed tarball for Linux x64. MUST pass for any PR that
+  touches the prebuild pipeline or `binding.gyp`.
+- `npm run verify:tarball` — runs `scripts/smoke-packed-package.js`,
+  the cross-platform packed-tarball smoke. MUST pass for any prebuild
+  change.
+
+A future `prebuild-smoke` gate covering the full matrix is a follow-up
+item; wiring it into `.loswf/config.yaml` is out of scope for this
+spec.
+
+## Out of Scope
+
+- Release tagging, version bumps, and `npm publish` orchestration
+  (see [`release-pipeline.md`](./release-pipeline.md)).
+- The TypeScript public API shape (see
+  [`typescript-surface.md`](./typescript-surface.md)).
+- Cross-runtime support (Deno, Bun, browser) — explicitly ruled out by
+  VISION non-goals.
+- Adding platforms beyond the SRS section 5 matrix.

--- a/specs/release-pipeline.md
+++ b/specs/release-pipeline.md
@@ -1,0 +1,94 @@
+# Spec — Release Pipeline
+
+## Scope
+
+This spec scopes the release plumbing for `@xifty/xifty`: how a tagged
+commit becomes a published npm tarball with prebuild artifacts attached,
+and the guardrails that keep that pipeline honest. It does NOT scope
+the matrix of platforms being built (see
+[`prebuild-matrix.md`](./prebuild-matrix.md)) or the TypeScript public
+surface (see [`typescript-surface.md`](./typescript-surface.md)).
+
+## Anchors
+
+- **SRS**: [`SRS.md`](./SRS.md) section 2 (release plumbing), section 6
+  (Release Guardrails).
+- **VISION**: [`VISION.md`](./VISION.md) principle 7
+  ("Release discipline") and principle 4 ("Packed-package parity").
+- **Code**:
+  - `package.json` `scripts.publish:local` (line 51) — the full
+    release chain. The script is not a single command; it is an
+    ordered pipeline:
+    1. `npm run build:prebuilds` → `node scripts/prebuild-release.js`
+       produces every platform prebuild for the release matrix.
+    2. `npm run verify:package` → `node scripts/verify-package.js`
+       validates the `package.json` `files` manifest and the packed
+       tarball contents.
+    3. `npm run verify:tarball` → `node scripts/smoke-packed-package.js`
+       runs a cross-platform packed-tarball smoke.
+    4. `npm run verify:linux-x64` → `node scripts/smoke-linux-x64.js`
+       runs the Linux x64 packed-tarball smoke.
+    5. `npm publish --access public` actually publishes the tarball.
+  - `scripts/prebuild-release.js` — prebuild matrix driver.
+  - `scripts/verify-package.js` — tarball / `files` manifest check.
+  - `scripts/smoke-packed-package.js` — cross-platform packed smoke.
+  - `scripts/smoke-linux-x64.js` — linux-x64 packed smoke.
+  - `package.json` `scripts.prepack` (line 57) — runs `build:ts` so
+    the `dist/` in the published tarball is always freshly compiled.
+- **Guardrails** (`.loswf/config.yaml` lines 46-51):
+  - Never push directly to `main`; all changes go through a PR.
+  - Never use `--no-verify` on git commits.
+  - Do not bump `package.json` `version` without an explicit release
+    task.
+
+## Acceptance Criteria
+
+A change under this spec is acceptable when:
+
+1. **Tagged-commit parity.** The git commit that produces the prebuild
+   artifacts MUST be the same commit whose `package.json` `version` is
+   tagged and whose tarball is published. The `publish:local` chain
+   runs prebuilds and publish on a single working tree — no recipe may
+   split them across commits.
+2. **All pre-publish gates run.** Any change to `publish:local` MUST
+   preserve the ordered chain `build:prebuilds` →
+   `verify:package` → `verify:tarball` → `verify:linux-x64` →
+   `npm publish`. Removing or reordering steps is a breaking change to
+   this spec.
+3. **No hook bypass.** Commits made by the release task MUST NOT use
+   `--no-verify`. The repo guardrail is absolute; no release recipe may
+   add a bypass.
+4. **No incidental version bumps.** `package.json` `version` changes
+   ONLY in a commit whose sole purpose is a release. A feature, fix, or
+   docs PR MUST NOT modify `version`.
+5. **Prepack invariant.** `prepack` MUST continue to run `build:ts` so
+   `dist/` in the published tarball matches `src/` at the tagged
+   commit.
+6. **Files manifest integrity.** `scripts/verify-package.js` MUST pass;
+   the published tarball contains exactly the `files` entries declared
+   in `package.json` (`binding.gyp`, `dist/**`, `prebuilds/**`,
+   `scripts/**`, `src/**`, `README.md`, `LICENSE`) and nothing else.
+
+## Additional Validation Gates
+
+In addition to the three base gates in `.loswf/config.yaml`
+(`typecheck`, `test`, `verify-package`):
+
+- `npm run verify:tarball` — packed-tarball smoke (`smoke-packed-package.js`).
+- `npm run verify:linux-x64` — Linux x64 packed-tarball smoke.
+
+Both SHOULD run for any PR that touches the release chain, `binding.gyp`,
+or files entering the published tarball.
+
+## Out of Scope
+
+- The per-platform build matrix itself — scoped by
+  [`prebuild-matrix.md`](./prebuild-matrix.md).
+- The TypeScript public API — scoped by
+  [`typescript-surface.md`](./typescript-surface.md).
+- CI workflow automation: `.loswf/config.yaml` sets `ci_check: false`
+  because workflow runs are currently flaky. Re-enabling CI as a gate
+  is a separate follow-up.
+- A fully remote release pipeline (GitHub Actions driven release).
+  `publish:local` is the current source of truth; moving to a
+  workflow-driven release is a future change.

--- a/specs/typescript-surface.md
+++ b/specs/typescript-surface.md
@@ -1,0 +1,83 @@
+# Spec — TypeScript Public Surface
+
+## Scope
+
+This spec scopes the public JavaScript/TypeScript API that `@xifty/xifty`
+exposes to consumers of `require("@xifty/xifty")`: the exported types,
+exported functions, module shape, and the typechecking gate that guards
+them. It does NOT scope the native binding's internal C++ surface, the
+prebuild matrix (see [`prebuild-matrix.md`](./prebuild-matrix.md)), or
+the release pipeline (see [`release-pipeline.md`](./release-pipeline.md)).
+
+## Anchors
+
+- **SRS**: [`SRS.md`](./SRS.md) section 2 (public JS/TS API) and
+  section 4 (Validation Configuration, `typecheck` gate).
+- **VISION**: [`VISION.md`](./VISION.md) principle 1
+  ("Typed surface first") and the "Not ESM-first" non-goal
+  (CommonJS shipping shape).
+- **Code**:
+  - `src/index.ts` — single source of truth for the exported API
+    (types `ViewName`, `ExtractOptions`, `InputSummary`, `Provenance`,
+    `TypedValue`, `NormalizedField`, `ReportIssue`, `ReportConflict`,
+    `XiftyEnvelope`; functions `packageVersion`, `version`, `probe`,
+    `extract`; default export).
+  - `tsconfig.json` — compiler settings that produce `dist/`.
+  - `dist/index.d.ts` — the declaration file consumers actually see
+    (published as `types` in `package.json`).
+  - `package.json` `exports` block (lines 8-14) — the module shape
+    contract: `types` → `./dist/index.d.ts`, `require` and `default` →
+    `./dist/index.js`. No `import` conditional: this package is CJS.
+  - `package.json` `main` (line 6) and `types` (line 7) — legacy
+    resolution fallbacks; MUST stay in sync with `exports`.
+
+## Acceptance Criteria
+
+A change under this spec is acceptable when:
+
+1. **Every public symbol is typed.** Every `export` from `src/index.ts`
+   (types, interfaces, functions, default export) has a precise type
+   declaration; no `any` on public signatures.
+2. **`tsc -p tsconfig.json --noEmit` passes.** This is the first
+   `validate` gate in `.loswf/config.yaml` (line 36) and is the
+   binding contract for the type surface.
+3. **`dist/index.d.ts` is the published surface.** The declarations
+   emitted into `dist/index.d.ts` match the exports from `src/index.ts`;
+   consumers MUST NOT need to reach into implementation files for
+   types.
+4. **CommonJS-only module shape.** `package.json` `exports` stays
+   CJS-only (`require` + `default` pointing at `./dist/index.js`).
+   Adding an `import` conditional or shipping ESM output is a breaking
+   change to this spec and requires an explicit release task.
+5. **`main`, `types`, and `exports` agree.** If the emitted filenames
+   change, all three MUST be updated in the same PR.
+6. **Breaking type changes require a release task.** Renaming,
+   removing, or narrowing an exported type is a breaking change and
+   MUST be paired with an explicit version bump via the release
+   pipeline (see [`release-pipeline.md`](./release-pipeline.md)) — not
+   slipped into an unrelated PR.
+7. **Envelope views stay stable.** The `ViewName` union
+   (`full | raw | interpreted | normalized | report`) matches the four
+   views named in VISION ("raw", "interpreted", "normalized",
+   "report") plus the default `full` envelope. Adding a view is an
+   additive change; removing or renaming one is breaking.
+
+## Additional Validation Gates
+
+No additional gates beyond the three in `.loswf/config.yaml`. The
+`typecheck` gate is the core guard for this spec; `test` exercises the
+runtime shape; `verify-package` confirms `dist/index.d.ts` ships in the
+tarball.
+
+## Out of Scope
+
+- **Modifying current implementation.** This spec describes the
+  contract the surface must satisfy; it is not a demand to refactor
+  `src/index.ts` in the PR that introduces this spec. Existing code is
+  presumed compliant unless a specific follow-up issue says otherwise.
+- The native binding's C++ surface (`binding.gyp` / `src/*.cc`).
+- Prebuild matrix behavior and install-time resolution
+  (see [`prebuild-matrix.md`](./prebuild-matrix.md)).
+- Release orchestration (see [`release-pipeline.md`](./release-pipeline.md)).
+- ESM support and cross-runtime targets (Deno/Bun/browser) — explicit
+  VISION non-goals.


### PR DESCRIPTION
## Summary
- Files three capability specs under `specs/` (prebuild-matrix, release-pipeline, typescript-surface), each anchored to a named VISION principle and SRS section, each declaring its own acceptance criteria and any additional validation gates beyond the three base gates.
- Replaces the placeholder prose in `specs/SRS.md` section 3 with a real index linking the new specs.
- Materializes the approved plan at `specs/drafts/8-missing-specs.md` so reviewers can read it from the branch.

Closes #8.

## Notes for reviewer
- Docs-only change. No `src/`, `scripts/`, or `package.json` edits.
- `release-pipeline.md` cites the full `publish:local` chain (build:prebuilds → verify:package → verify:tarball → verify:linux-x64 → npm publish) per the plan-reviewer quality note, not just the top-level script name.
- `typescript-surface.md` carries an explicit "not a demand to refactor `src/index.ts`" out-of-scope clause.

## Validation
- `tsc -p tsconfig.json --noEmit` — passes.
- `npm test` — 11/11 pass (after building a local dev prebuild with `XIFTY_BUILD_FROM_SOURCE=1 npm run build:prebuilds:local`).
- `npm run verify:package` — pre-existing environmental failure on this dev worktree (missing `prebuilds/linux-x64/@xifty+xifty.node`); reproduces identically on `main` without these changes. Docs-only diff cannot have introduced it.

## Test plan
- [ ] Confirm `specs/prebuild-matrix.md`, `specs/release-pipeline.md`, and `specs/typescript-surface.md` are present and each cite their SRS section + VISION principle.
- [ ] Confirm `specs/SRS.md` section 3 links all three.
- [ ] Confirm no files outside `specs/` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)