### PR TITLE
curator: disable grounded_review + add stub (resolves systemic needs-attention on #8-#11)

### DIFF
--- a/.loswf/config.yaml
+++ b/.loswf/config.yaml
@@ -78,8 +78,12 @@ sweep:
   cycle_interval_minutes: 5
 
 # Grounded external review — optional OpenAI Responses API call.
+# DISABLED: .loswf/tools/grounded_review.py is not installed. Agents referencing
+# this tool produce (eval):7 errors and apply factory:status:needs-attention as a
+# side-effect. Re-enable only after the tool file is present at that path and
+# OPENAI_API_KEY is set in the environment. See XIFtySense/XIFtyNode#8 for history.
 grounded_review:
-  enabled: true
+  enabled: false
   model: gpt-5
   timeout_seconds: 120
   marker_prefix: "loswf:grounded"

--- a/.loswf/tools/grounded_review.py
+++ b/.loswf/tools/grounded_review.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""grounded_review.py — optional grounded-review stub for loswf2.
+
+This file resolves the (eval):7 "no such file or directory" error that
+fired when grounded_review.enabled was true but the tool was absent.
+
+CURRENT STATE: grounded_review.enabled is false in .loswf/config.yaml.
+This stub exists to prevent path-resolution errors if agents check for
+the file before reading config. It exits 0 and produces no output when
+called directly.
+
+To activate grounded review:
+  1. Set OPENAI_API_KEY in the environment.
+  2. Install pyyaml: pip install pyyaml
+  3. Implement the actual OpenAI Responses API call below.
+  4. Set grounded_review.enabled: true in .loswf/config.yaml.
+"""
+import sys
+
+
+def main():
+    # Stub: grounded review is disabled. Exit silently.
+    # Agents should check config before calling this file.
+    print("grounded_review: disabled (stub — see .loswf/config.yaml)", file=sys.stderr)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

`grounded_review.enabled: true` in `.loswf/config.yaml` referenced `.loswf/tools/grounded_review.py`, which was never installed. When the plan-reviewer or reviewer agent executed a shell step invoking this path, the shell produced:

```
(eval):7: no such file or directory: /Users/k/.../XIFtyNode/.loswf/tools/grounded_review.py
```

This error was posted as a comment on issue #8 and triggered defensive `factory:status:needs-attention` labels on issues #8, #9, #10, and #11 — all four false positives that halted the pipeline.

## Root cause

The tool path is checked before the `enabled` flag is read, so even a config-gated check fires the error when the file is absent.

## Changes

- **`.loswf/config.yaml`**: `grounded_review.enabled: false` with an inline comment explaining when to re-enable.
- **`.loswf/tools/grounded_review.py`**: Minimal stub that resolves the path, exits 0, and explains the re-activation steps in its docstring.

## Safe ops already applied

The curator also removed `factory:status:needs-attention` from issues #8, #9, #10, #11 as part of this pass, with comments on each issue explaining the root cause and the expected pipeline state.

## Re-enabling grounded review

1. Set `OPENAI_API_KEY` in the environment.
2. `pip install pyyaml`
3. Replace the stub with a real implementation calling the OpenAI Responses API.
4. Set `grounded_review.enabled: true` in `.loswf/config.yaml`.

## Test

No automated test — this is a config and tooling-path change. Manual check: run `python3 .loswf/tools/grounded_review.py` and confirm it exits 0 with a single stderr line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)