### PR TITLE
curator: fix post-intake silent no-op — exclude needs-clarification + needs-attention from sweep

### DIFF
--- a/.loswf/adws/adw_sweep.sh
+++ b/.loswf/adws/adw_sweep.sh
@@ -41,10 +41,16 @@ list_phase() {
 }
 
 # 1. Triage anything without a phase label.
+# Exclude factory:status:needs-clarification — those issues require author response
+# before intake can assign a type. Running intake again without author input is a
+# silent no-op that wastes a sweep cycle and can produce repeated comments.
+# The curator closes these after 14 days of no response.
 log "phase: intake"
 gh issue list --state open --json number,labels --jq \
   '.[] | select([.labels[].name] | any(startswith("factory:phase:")) | not)
-       | select(([.labels[].name] | any(. == "factory:hold")) | not)
+       | select(([.labels[].name] | any(. == "factory:hold"
+                                      or . == "factory:status:needs-clarification"
+                                      or . == "factory:status:needs-attention")) | not)
        | .number' \
   | while read -r issue; do
       [ -z "$issue" ] && continue


### PR DESCRIPTION
## Problem

The sweep intake query in `adw_sweep.sh` matched every open issue without a `factory:phase:*` label, including issues already carrying `factory:status:needs-clarification` or `factory:status:needs-attention`. This created two silent no-op loops:

**Loop 1 — needs-clarification re-intake:** When `post_intake` finds no `factory:type:*` label, it applies `factory:status:needs-clarification` and returns without setting a phase. On the next sweep, the intake query finds the same issue again (no phase label), re-runs intake, finds the same missing type, and applies `needs-clarification` a second time — or posts a duplicate comment. This repeats every `cycle_interval_minutes` until the author responds or the curator closes the issue after 14 days.

**Loop 2 — needs-attention re-intake:** Issues with `factory:status:needs-attention` and no phase label (a state that can arise when a phaseless issue is escalated before intake completes) would be picked up by intake instead of being held for human triage.

## Fix

Extend the jq filter in the intake loop to also exclude `factory:status:needs-clarification` and `factory:status:needs-attention`. This is a pure guard addition — no existing issue that should flow through intake is excluded.

Responsibilities remain unchanged:
- The **curator** closes stale `needs-clarification` issues after 14 days with no author response.
- **Human triage** handles `needs-attention` issues.

## Related

Companion to PR #17 (grounded_review tool gap fix), which is the observed trigger for this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)