### PR TITLE
docs: rework npm landing page — value-first, deeper detail moved to docs/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,18 @@ jobs:
       - name: Run tests
         run: npm test
 
+      # The smoke step packs the package and installs it into a temp dir.
+      # That temp install runs the package's install hook which deliberately
+      # skips a source build, so it can only succeed if prebuilds/ is populated.
+      # We populate the local platform's prebuild here (no Docker, no cross-
+      # compile) so the smoke loads cleanly on whatever Node version the CI
+      # runner uses. The release-cut maintainer flow (publish:local) handles
+      # the Linux-x64 prebuild via Docker separately.
+      - name: Build local-platform prebuild for smoke
+        env:
+          XIFTY_CORE_DIR: ${{ github.workspace }}/XIFty
+        run: npm run build:prebuilds:local
+
       - name: Smoke packed tarball
         run: npm run verify:tarball
 

--- a/README.md
+++ b/README.md
@@ -1,244 +1,103 @@
 # XIFty for Node.js
 
-`@xifty/xifty` is the official Node.js package for XIFty.
-
-It gives Node applications a typed, native bridge into XIFty’s metadata engine
-so you can inspect files and extract metadata without shelling out to external
-tools.
-
-## Install
+Read metadata from images, video, and audio — locally, without shelling
+out, with stable normalized fields you can ship to product code.
 
 ```bash
 npm install @xifty/xifty
 ```
 
-## What It Does
-
-XIFty is built around four views of metadata:
-
-- `raw`: direct extracted metadata values
-- `interpreted`: decoded values with namespace meaning
-- `normalized`: stable cross-format fields for application use
-- `report`: issues and conflicts surfaced honestly
-
-This package exposes the same model directly in Node.
-
-## Quick Example
-
 ```js
 const xifty = require("@xifty/xifty");
-
 const result = xifty.extract("photo.jpg", { view: "normalized" });
 
-console.log(result.input.detected_format);
-console.log(result.normalized.fields);
-```
-
-Typical normalized use:
-
-```js
 const fields = Object.fromEntries(
-  result.normalized.fields.map((field) => [field.field, field.value.value]),
+  result.normalized.fields.map((f) => [f.field, f.value.value]),
 );
 
-console.log(fields["device.make"]);
-console.log(fields["device.model"]);
-console.log(fields["captured_at"]);
+fields["device.make"];      // "Apple"
+fields["device.model"];     // "iPhone 15 Pro"
+fields["captured_at"];      // "2026-04-21T14:33:08-04:00"
+fields["location"];         // { latitude: 40.7922, longitude: -73.9584 }
 ```
 
-## API
+## What you get
 
-### `xifty.version(): string`
+XIFty extracts metadata from a wide range of media containers and
+surfaces it in four views — `raw`, `interpreted`, `normalized`, and
+`report` — so you can use clean stable fields in product code without
+losing access to the underlying values when provenance matters.
 
-Returns the XIFty core version reported by the native library.
+### Formats supported today
 
-### `xifty.packageVersion(): string`
+| Container | Decoders |
+|---|---|
+| **JPEG / TIFF / DNG** | EXIF · XMP · ICC · IPTC |
+| **PNG / WebP** | EXIF · XMP · ICC · IPTC |
+| **HEIF / HEIC** | EXIF · XMP · ICC · IPTC · item-based dimensions |
+| **MP4 / MOV** | QuickTime · iTunes · ICC · XMP · Apple/Sony vendor metadata · **DJI drone telemetry** |
+| **M4A / M4B / M4P** | iTunes `ilst` (title, artist, album, year, genre, track number, cover art …) |
+| **FLAC** | Native stream info · Vorbis comments · embedded picture |
+| **OGG (Vorbis / Opus)** | Page parsing · ident headers · Vorbis comments |
+| **AIFF / AIFC** | Stream info from `COMM` chunk |
 
-Returns the npm package version.
+### Normalized fields
 
-### `xifty.probe(path: string): XiftyEnvelope`
+The `normalized` view gives you cross-format stable keys so you don't
+have to know whether a given file was JPEG-EXIF or DJI-`udta` or
+Vorbis-comment:
 
-Detects the input format and returns a lightweight envelope describing the file.
+- `device.make`, `device.model`, `device.serial_number`
+- `captured_at`, `created_at`, `modified_at`
+- `location` (latitude, longitude, altitude)
+- `dimensions.width`, `dimensions.height`, `orientation`
+- `exposure.iso`, `exposure.aperture`, `exposure.shutter_speed`, `exposure.focal_length_mm`
+- `lens.make`, `lens.model`
+- `duration`, `video.framerate`, `video.bitrate`, `codec.video`, `codec.audio`
+- `audio.channels`, `audio.sample_rate`, `audio.bit_depth`
+- `drone.flight.{pitch,yaw,roll}_deg`, `drone.gimbal.{pitch,yaw,roll}_deg`, `drone.speed.{x,y,z}_mps`
+- `author`, `copyright`, `headline`, `description`, `keywords`
+- `color.space`, `color.profile.name`, `color.profile.class`
 
-Example:
+When fields disagree across sources (e.g. EXIF vs. XMP), the `report`
+view tells you the conflict explicitly rather than silently picking
+one.
+
+## Try it
 
 ```js
-const probe = xifty.probe("image.jpg");
-console.log(probe.input);
+const { extract, probe } = require("@xifty/xifty");
+
+// Lightweight format detection — no full extraction
+probe("clip.mp4").input.detected_format;   // "mp4"
+
+// Drone telemetry from a DJI MP4 — same API, same shape
+const dji = extract("DJI_0003.MP4", { view: "normalized" });
+const fields = Object.fromEntries(
+  dji.normalized.fields.map((f) => [f.field, f.value.value])
+);
+fields["drone.gimbal.pitch_deg"];   // -31.2
+fields["drone.flight.yaw_deg"];     // 175.5
+fields["device.serial_number"];     // "53HQN4T0M5B7JW"
 ```
 
-### `xifty.extract(path: string, options?): XiftyEnvelope`
+## Common use cases
 
-Extracts metadata for the input file.
+- Photo / video library ingestion (EXIF, XMP, GPS, capture time)
+- Drone footage indexing (DJI flight + gimbal telemetry, GPS, model)
+- AWS Lambda media-pipeline upload handlers
+- Media-asset deduplication and search
+- Audio library tagging (Vorbis comments across FLAC, OGG, Opus)
+- Compliance audits (provenance via `raw` + `report` views)
 
-Supported `view` values:
+## More documentation
 
-- `"full"`
-- `"raw"`
-- `"interpreted"`
-- `"normalized"`
-- `"report"`
+- **[API reference](./docs/api.md)** — every method, every option, every output field
+- **[AWS Lambda](./docs/aws-lambda.md)** — runtime targets, SAM example, layer assembly
+- **[Supported platforms](./docs/platforms.md)** — what ships, what doesn't, why
+- **[Local development](./docs/development.md)** — building from source, running tests
+- **[Releasing](./RELEASING.md)** — maintainer guide for cutting a new version
 
-Example:
+## License
 
-```js
-const normalized = xifty.extract("image.jpg", { view: "normalized" });
-const report = xifty.extract("image.jpg", { view: "report" });
-```
-
-Numeric view selection is also supported for low-level consumers, but named
-views are the intended public API.
-
-## Output Shape
-
-Every call returns a JSON-like envelope with the same top-level structure:
-
-```js
-{
-  schema_version,
-  input,
-  raw,
-  interpreted,
-  normalized,
-  report
-}
-```
-
-That shape is intentionally close to the core CLI and C ABI so behavior stays
-predictable across the XIFty ecosystem.
-
-## TypeScript
-
-The public wrapper is written in TypeScript and ships declaration files.
-
-Example:
-
-```ts
-import { extract } from "@xifty/xifty";
-
-const result = extract("image.jpg", { view: "normalized" });
-```
-
-## Why Use It
-
-Use this package when you want:
-
-- a native Node interface instead of shelling out to CLI tools
-- stable normalized fields for app logic
-- access to raw and interpreted metadata when provenance matters
-- explicit issue/conflict reporting instead of silent lossy parsing
-
-Common application fits:
-
-- photo-library ingestion
-- media indexing pipelines
-- upload-time metadata extraction
-- back-office asset processing
-
-## AWS Lambda
-
-`@xifty/xifty` is the recommended XIFty runtime for AWS Lambda today.
-
-The published package currently targets:
-
-- `linux-x64`
-- `macos-arm64`
-
-That means the package is ready for `nodejs22.x` Lambda on `x86_64`, local
-Apple Silicon development, and common Linux server/CI environments.
-
-For the first-party Lambda adoption path, start from:
-
-- the core repo Lambda guide:
-  [docs/adoption/AWS_LAMBDA_NODE.md](https://github.com/XIFtySense/XIFty/blob/main/docs/adoption/AWS_LAMBDA_NODE.md)
-- the checked-in SAM example:
-  [examples/aws-sam-node](https://github.com/XIFtySense/XIFty/tree/main/examples/aws-sam-node)
-
-## Supported Platforms
-
-Current published-package target:
-
-- `macos-arm64`
-- `linux-x64`
-
-`linux-x64` is the priority Linux target because it covers AWS Lambda
-`nodejs22.x`, most CI runners, and most general Linux servers.
-
-Not supported right now:
-
-- `macos-x64`
-- `windows-*`
-- `linux-arm64`
-- other Linux architectures
-
-If you install the package on an unsupported platform, it fails with a clear
-native-build error instead of silently pretending support.
-
-## Design Notes
-
-- native seam: `xifty-ffi`
-- Node bridge: `node-addon-api`
-- package loader: `node-gyp-build`
-- public surface: TypeScript + generated `.d.ts`
-
-Those are implementation details, but they matter for reliability: this package
-is a thin wrapper over the same XIFty core used elsewhere, not a separate
-reimplementation.
-
-## Local Development
-
-```bash
-npm install
-npm test
-npm run coverage
-node examples/basic_usage.js
-node examples/gallery_ingest.js
-```
-
-## Maintainer Notes
-
-GitHub Actions no longer publish this package. The current release path is
-local maintainer publish from an authenticated npm CLI session.
-
-Maintainer builds no longer assume a sibling `../XIFty` checkout. The build
-scripts resolve XIFty core in this order:
-
-1. `XIFTY_CORE_DIR` if you explicitly point at a local checkout
-2. a cached checkout of `https://github.com/XIFtySense/XIFty.git` at `main`
-
-You can override the cached source with:
-
-- `XIFTY_CORE_REPO`
-- `XIFTY_CORE_REF`
-- `XIFTY_CORE_CACHE_DIR`
-
-Useful commands:
-
-```bash
-npm run core:prepare
-npm run verify:package
-npm run verify:tarball
-npm run build:prebuilds
-npm run verify:linux-x64
-npm run publish:local
-```
-
-The local publish path now assembles a release bundle with:
-
-- the host `macos-arm64` prebuild when run on Apple Silicon macOS
-- a Lambda-compatible `linux-x64` prebuild built in an Amazon Linux 2023
-  container
-
-That means manual publish from a supported maintainer Mac produces a package
-that is ready for both local macOS use and AWS Lambda / Linux server use.
-
-For release-sensitive local verification against a real fixture, point the
-packed-tarball smoke test at the file and require the fields you care about.
-Example:
-
-```bash
-XIFTY_SMOKE_FIXTURE=/Users/k/Projects/XIFty/fixtures/local/C0242.MP4 \
-XIFTY_SMOKE_FIELDS=video.bitrate,audio.sample_rate \
-XIFTY_SMOKE_NONZERO_FIELDS=video.bitrate,audio.sample_rate \
-npm run verify:tarball
-```
+MIT. Built on the open-source [XIFty core](https://github.com/XIFtySense/XIFty).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,166 @@
+# API reference
+
+`@xifty/xifty` is a thin native bridge over the XIFty core. The public
+surface is small — three functions and a single envelope shape — so you
+can learn it once and apply it across every supported format.
+
+## Functions
+
+### `version(): string`
+
+Returns the XIFty core version reported by the native library.
+
+```js
+xifty.version();           // "0.1.7"
+```
+
+### `packageVersion(): string`
+
+Returns the npm package version.
+
+```js
+xifty.packageVersion();    // "0.1.9"
+```
+
+### `probe(path: string): XiftyEnvelope`
+
+Detects the input format and returns a lightweight envelope describing
+the file. No metadata extraction is performed — useful for quickly
+filtering or routing files before doing the heavier `extract` work.
+
+```js
+const probe = xifty.probe("photo.jpg");
+probe.input.detected_format;     // "jpeg"
+probe.input.size;                // 4_182_733
+probe.report.issues;             // []
+```
+
+### `extract(path: string, options?): XiftyEnvelope`
+
+Extracts metadata from the input file.
+
+```js
+const result = xifty.extract("clip.mp4", { view: "normalized" });
+```
+
+Options:
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `view` | `"full" \| "raw" \| "interpreted" \| "normalized" \| "report"` | `"full"` | Which view to populate. Other views in the envelope are still present but empty. |
+
+Numeric view selection is also supported for low-level consumers, but
+named views are the intended public API.
+
+## Views
+
+XIFty's design centres on four views over the same underlying metadata.
+Pick the one that fits your use case:
+
+| View | Use when |
+|---|---|
+| `raw` | You need the bytes-level values exactly as the source format encoded them. Provenance-sensitive work, debugging, parser correctness checks. |
+| `interpreted` | You want decoded namespaces (EXIF tags, XMP properties, iTunes atoms) with their meaning attached, but in their original namespace. |
+| `normalized` | You want stable cross-format keys (`device.make`, `captured_at`, `location`, …) for product code. **Most apps want this.** |
+| `report` | You want to know about parser warnings, namespace conflicts (EXIF vs. XMP disagreement), or unsupported structure. Always populated. |
+
+## Envelope shape
+
+Every call returns the same top-level shape:
+
+```ts
+{
+  schema_version: "0.1.0",
+  input: {
+    detected_format: string;     // "jpeg", "mp4", "ogg", etc.
+    container: string;           // top-level container kind
+    size: number;                // bytes
+  },
+  raw: { ... } | null,
+  interpreted: { ... } | null,
+  normalized: {
+    fields: Array<{
+      field: string;             // "device.make", "captured_at", …
+      value: { kind: string; value: any };
+      sources: Array<Provenance>;
+      notes: string[];
+    }>;
+  } | null,
+  report: {
+    conflicts: Array<{
+      field: string;
+      message: string;
+      sources: Array<{ namespace, value, ... }>;
+    }>;
+    issues: Array<{
+      severity: "info" | "warning" | "error";
+      code: string;
+      message: string;
+      offset: number | null;
+      context: string | null;
+    }>;
+  }
+}
+```
+
+Views you didn't ask for are returned as `null`, except `report` which
+is always populated (an empty `{ conflicts: [], issues: [] }` is a
+positive signal — XIFty saw the file cleanly).
+
+## Working with the normalized view
+
+The normalized view is a list of fields, not a key/value object. To
+turn it into a flat object:
+
+```js
+const result = xifty.extract("photo.jpg", { view: "normalized" });
+
+const fields = Object.fromEntries(
+  result.normalized.fields.map((f) => [f.field, f.value.value])
+);
+
+fields["device.make"];
+fields["captured_at"];
+fields["location"];   // { latitude, longitude, altitude? } when present
+```
+
+Each field carries `sources` (provenance — which container, namespace,
+byte offsets the value came from) and `notes` (e.g. "selected EXIF
+Make over XMP tiff:Make"). If you need that detail, iterate `fields`
+directly instead of flattening.
+
+## TypeScript
+
+Type definitions are bundled. The named import works the same way:
+
+```ts
+import { extract, probe } from "@xifty/xifty";
+
+const result = extract("image.jpg", { view: "normalized" });
+```
+
+Use the `XiftyEnvelope` type for explicit return-type annotations.
+
+## Error handling
+
+Errors surface as thrown `Error` instances with descriptive messages.
+The two main classes:
+
+- **I/O errors** — file not found, permission denied, etc.
+- **Parse errors** — XIFty couldn't recognise the input as a supported
+  container (e.g. truncated file, wrong magic bytes).
+
+For partial-parse situations (file is recognized but some structure is
+malformed), XIFty *does not throw* — it surfaces issues in
+`result.report.issues` so you can inspect what was readable. This is by
+design; throwing on every minor issue would force callers to wrap every
+extraction in try/catch.
+
+## Memory & performance
+
+- The native library reads the file once and reuses the buffer across
+  all four views. There is no per-view re-parse cost.
+- For large files (multi-GB drone MP4, RAW), only the metadata atoms
+  are read — the media `mdat` payload is skipped.
+- `probe` is much cheaper than `extract`. If you only need to know
+  "what kind of file is this?" use `probe`.

--- a/docs/aws-lambda.md
+++ b/docs/aws-lambda.md
@@ -1,0 +1,97 @@
+# AWS Lambda
+
+`@xifty/xifty` is the recommended XIFty runtime for AWS Lambda. The
+published package ships prebuilt native binaries for Lambda's standard
+runtimes, so you do not need to compile from source in CI.
+
+## Runtime targets
+
+The published package currently bundles prebuilds for:
+
+- `linux-x64` (Lambda `nodejs22.x`, most CI runners, general Linux servers)
+- `macos-arm64` (Apple Silicon local development)
+
+Each prebuild is exercised by smoke tests at publish time — if the
+package made it to the registry, both prebuilds are known to load and
+extract metadata from real fixtures.
+
+## Quick start
+
+The fastest path is to install the package directly into your Lambda
+deployment (zip-style) or a Lambda Layer.
+
+### Option 1 — Direct install in your function
+
+```bash
+npm install @xifty/xifty
+```
+
+Your handler:
+
+```js
+const xifty = require("@xifty/xifty");
+
+exports.handler = async (event) => {
+  const result = xifty.extract(event.path, { view: "normalized" });
+  const fields = Object.fromEntries(
+    result.normalized.fields.map((f) => [f.field, f.value.value])
+  );
+  return {
+    statusCode: 200,
+    body: JSON.stringify(fields),
+  };
+};
+```
+
+### Option 2 — Lambda Layer
+
+Use `tools/build-node-lambda-layer.sh` from the [XIFty core
+repo](https://github.com/XIFtySense/XIFty) to assemble a layer
+containing only the `linux-x64` prebuild — keeps the layer slim and
+under the 50 MB unzipped limit.
+
+```bash
+./tools/build-node-lambda-layer.sh ./layer-build ./xifty-lambda-layer.zip
+```
+
+Then upload the resulting zip as a Lambda Layer through the AWS
+console, CDK, SAM, or Terraform.
+
+## SAM example
+
+A working SAM example is checked into the core repo:
+[`examples/aws-sam-node`](https://github.com/XIFtySense/XIFty/tree/main/examples/aws-sam-node).
+It demonstrates:
+
+- A Lambda function consuming `@xifty/xifty`
+- A SAM template wiring the function to an API Gateway
+- Local invocation via `sam local invoke` against a real fixture
+- Layer assembly + validation via the workflow used by the core repo's
+  CI
+
+See also the broader [Lambda adoption
+guide](https://github.com/XIFtySense/XIFty/blob/main/docs/adoption/AWS_LAMBDA_NODE.md)
+in the core repo.
+
+## Performance notes
+
+- The native library reads the input file once. Multi-view extracts
+  (e.g. `view: "full"`) do not re-parse.
+- For multi-GB inputs, only metadata atoms are read — the media payload
+  is skipped. Cold-start memory should sit well under 256 MB even for
+  drone MP4s.
+- Cold-start cost dominates first-call latency. Subsequent invocations
+  on a warm container reuse the loaded native module.
+
+## Troubleshooting
+
+- **"node-gyp-build failed to find prebuild"** on `arm64` Linux —
+  `linux-arm64` is not currently a published prebuild target. Use a
+  `linux-x64` Lambda runtime, or open an issue requesting `arm64`
+  support.
+- **"undefined symbol"** at load time — usually means the wrong glibc
+  version. Lambda's Amazon Linux 2023 runtimes are tested; older
+  Lambda runtimes (`nodejs16.x`, `nodejs18.x`) are end-of-life and
+  unsupported.
+- **Layer size limits** — keep only the platform you need. The prebuilds
+  directory accepts surgical pruning before zipping.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,101 @@
+# Local development
+
+This document is for working on `@xifty/xifty` itself — building from
+source, running tests, and iterating on the native bridge. Releasing
+new versions is covered in [RELEASING.md](../RELEASING.md).
+
+## Setup
+
+```bash
+git clone git@github.com:XIFtySense/XIFtyNode.git
+cd XIFtyNode
+npm install
+```
+
+`npm install` will trigger a source build of the native addon if no
+prebuild matches your platform. On supported platforms (Apple Silicon
+macOS, Linux x64) the bundled prebuild is used and no Rust toolchain is
+required.
+
+## Building from source
+
+To build the native addon explicitly (e.g. after changing the XIFty
+core or `xifty-ffi`):
+
+```bash
+npm run build:debug          # debug profile, fast iteration
+npm run build                # release profile + TS compile
+npm run build:prebuilds      # produces ./prebuilds/<platform>/...
+```
+
+By default the build resolves the XIFty core in this order:
+
+1. `XIFTY_CORE_DIR` if set — use a local checkout
+2. Cached clone of `https://github.com/XIFtySense/XIFty.git` at `main`
+
+Override via:
+
+| Variable | Effect |
+|---|---|
+| `XIFTY_CORE_DIR` | Point at a local checkout of the core repo |
+| `XIFTY_CORE_REPO` | Override the upstream repo URL |
+| `XIFTY_CORE_REF` | Pin to a specific tag/branch/SHA |
+| `XIFTY_CORE_CACHE_DIR` | Where the cached clone lives |
+| `XIFTY_CARGO_PROFILE` | `debug` or `release` (default `release`) |
+| `XIFTY_FORCE_BUILD` | `1` to skip prebuild lookup and always source-build |
+
+## Tests
+
+```bash
+npm test                     # node --test test/*.test.js
+npm run coverage             # via c8
+```
+
+The test suite covers:
+
+- Native addon loading
+- Round-trip of `extract` and `probe` against checked-in fixtures
+- View selection (`raw`, `interpreted`, `normalized`, `report`, `full`)
+- Error handling (missing files, invalid view names, malformed inputs)
+
+## Examples
+
+```bash
+node examples/basic_usage.js
+node examples/gallery_ingest.js
+```
+
+The `basic_usage.js` example extracts metadata from a JPEG fixture and
+prints the normalized fields. `gallery_ingest.js` walks a directory and
+builds a metadata index — closer to a real ingestion pipeline.
+
+## Useful commands during development
+
+```bash
+npm run core:prepare         # ensure XIFty core is fetched + cached
+npm run verify:package       # sanity-check `npm pack` contents
+npm run verify:tarball       # pack + smoke the tarball end-to-end
+npm run verify:linux-x64     # smoke just the linux-x64 prebuild
+```
+
+`verify:tarball` is the highest-confidence check before publishing —
+it tests what consumers actually install, not what's on disk.
+
+## Releasing
+
+See [RELEASING.md](../RELEASING.md). Short version: bump version, push
+tag, run `npm run publish:local` from a machine that has Docker and a
+bypass-2fa npm token in `~/.npmrc`.
+
+## Code layout
+
+- `src/index.ts` — the public TypeScript surface
+- `src/addon.cc` — the C++ Node addon glue (uses `node-addon-api`)
+- `binding.gyp` — native build config
+- `scripts/` — install hook, build helpers, smoke tests
+- `test/` — unit and integration tests
+- `examples/` — runnable usage examples
+
+The native bridge intentionally stays thin: all metadata logic lives in
+the [XIFty core](https://github.com/XIFtySense/XIFty) Rust workspace,
+and this package is just a typed Node entry point onto `xifty-ffi`.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -1,0 +1,55 @@
+# Supported platforms
+
+`@xifty/xifty` ships prebuilt native binaries. If you install on a
+listed target, the package works without any local toolchain. On an
+unsupported target, the install script fails fast with a clear error
+rather than silently pretending to work.
+
+## Currently shipped
+
+| Platform | Prebuild | Notes |
+|---|---|---|
+| `darwin` / `arm64` | ✅ | Apple Silicon — local development |
+| `linux` / `x64` | ✅ | AWS Lambda `nodejs22.x`, most CI runners, general Linux servers |
+
+`linux-x64` is the priority Linux target because it covers the largest
+production surface (Lambda, common CI, general server distros).
+
+## Not currently shipped
+
+| Platform | Why |
+|---|---|
+| `darwin` / `x64` | Intel Mac volume has dropped sharply; cross-build complexity not yet justified. |
+| `linux` / `arm64` | Graviton Lambda is a real target — open an issue if you need this. |
+| `windows` / `*` | No published prebuild yet. Source builds work but require a working `node-gyp` toolchain. |
+| Other Linux architectures | Source builds may work via `XIFTY_FORCE_BUILD=1` but are unsupported. |
+
+## Source build (advanced)
+
+If you have a working `node-gyp` toolchain (Python 3, a C++ compiler,
+and a recent Rust toolchain), you can request a source build:
+
+```bash
+XIFTY_FORCE_BUILD=1 npm install @xifty/xifty
+```
+
+The install script will fetch the XIFty core source, compile
+`xifty-ffi`, and link the Node addon. Set `XIFTY_CORE_REF=v0.1.7` (or
+another tag) to pin to a specific core version; otherwise `main` is
+used.
+
+## Engine requirements
+
+- **Node.js**: 20 or newer. Older runtimes are not supported because
+  `node-addon-api` v8 dropped them.
+
+## Adding platform support
+
+If you need a platform we don't currently ship:
+
+1. **Open an issue** describing your target (OS, arch, Node version,
+   deployment context) so we can prioritise.
+2. **Try a source build** with `XIFTY_FORCE_BUILD=1` — most modern
+   platforms compile cleanly, you'll just need the toolchain locally.
+3. **Submit a CI matrix patch** — adding a prebuild target is mostly
+   matrix-config plumbing in the binding repo's CI.


### PR DESCRIPTION
See branch commit message for full rationale. Net: README 244→103 lines (value-first, capability table, common use cases). API/Lambda/platforms/development moved to discrete docs/ files. No source changes, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)