### PR TITLE
chore: bump to 0.1.11 for XIFty core v0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xifty/xifty",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xifty/xifty",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xifty/xifty",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Official Node package for XIFty",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Version bump to consume the \`v0.1.8\` core release. Brings in DJI drone telemetry extraction from JPG XMP (XIFtySense/XIFty#93).

## Publish

Once XIFty/PR #94 is merged and \`v0.1.8\` is tagged on the core repo:

\`\`\`bash
XIFTY_CORE_REF=v0.1.8 npm run publish:local
\`\`\`

(Needs your npm 2FA — automation token alone is rejected per \`RELEASING.md\`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)