### PR TITLE
Release Node package 0.1.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xifty/xifty",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xifty/xifty",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xifty/xifty",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Official Node package for XIFty",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bump `@xifty/xifty` `0.1.11` → `0.1.12`
- Pin to XIFty core **v0.1.9** (just released)

The headline change in core v0.1.9 is **#96 (mmap source)** — `SourceBytes::from_path` now memory-maps via `memmap2` instead of buffering the whole file into a `Vec<u8>`. This unblocks metadata extraction on multi-GB MP4s under tight memory ceilings (e.g. AWS Lambda 3 GB), which kstore-platform's ProcessVideo function was OOM-ing on for 2.8–4 GB DJI drone footage.

## Publish plan
After merge:
1. Tag `v0.1.12` on main
2. `XIFTY_CORE_REF=v0.1.9 npm run publish:local` (rebuilds prebuilds, verifies, then `npm publish --access public`)

## Test plan
- [x] `npm version patch` → 0.1.12 clean
- [ ] After merge: `publish:local` builds darwin-arm64 + linux-x64 prebuilds and verifies tarball before push