### PR TITLE
feat: expose sidecar discovery + sidecar-aware smoke harness (#23)

### DIFF
--- a/scripts/smoke-packed-package.js
+++ b/scripts/smoke-packed-package.js
@@ -72,6 +72,12 @@ const nonZeroFields = new Set(
     .map((field) => field.trim())
     .filter(Boolean),
 );
+const sidecarFields = (process.env.XIFTY_SMOKE_SIDECAR_FIELDS || "")
+  .split(",")
+  .map((field) => field.trim())
+  .filter(Boolean);
+const expectedSidecarNamespace =
+  process.env.XIFTY_SMOKE_SIDECAR_NAMESPACE || "sony_nrt";
 
 const requireFromTemp = createRequire(path.join(tempDir, "package.json"));
 const xifty = requireFromTemp("@xifty/xifty");
@@ -105,3 +111,37 @@ for (const fieldName of requiredFields) {
 process.stdout.write(
   `packed package smoke passed for ${path.basename(fixture)} with ${requiredFields.join(", ")}\n`,
 );
+
+// Optional sidecar-aware verification path. Set XIFTY_SMOKE_SIDECAR_FIELDS to a
+// comma list of normalized fields that must surface from a sidecar (e.g.
+// `umid,recording.mode,timecode.ltc.start`). Each field's `sources[]` is
+// asserted to contain at least one entry whose `namespace` equals
+// XIFTY_SMOKE_SIDECAR_NAMESPACE (default `sony_nrt`).
+if (sidecarFields.length > 0) {
+  const sidecarOutput = xifty.extract(fixture, {
+    view: "normalized",
+    sidecars: { discoverFrom: fixture },
+  });
+  const sidecarFieldsByName = fieldsByName(sidecarOutput);
+
+  for (const fieldName of sidecarFields) {
+    const field = sidecarFieldsByName[fieldName];
+    if (!field) {
+      process.stderr.write(
+        `packed package sidecar smoke failed: missing field ${fieldName} for fixture ${fixture} (sidecar discovery enabled)\n`,
+      );
+      process.exit(1);
+    }
+    const namespaces = (field.sources ?? []).map((source) => source.namespace);
+    if (!namespaces.includes(expectedSidecarNamespace)) {
+      process.stderr.write(
+        `packed package sidecar smoke failed: ${fieldName} has no source with namespace='${expectedSidecarNamespace}'; got namespaces=${JSON.stringify(namespaces)}\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  process.stdout.write(
+    `packed package sidecar smoke passed for ${path.basename(fixture)} with ${sidecarFields.join(", ")} (namespace=${expectedSidecarNamespace})\n`,
+  );
+}

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -101,10 +101,42 @@ Napi::Value ExtractJson(const Napi::CallbackInfo& info) {
   return Napi::String::New(env, json);
 }
 
+Napi::Value ExtractJsonWithOptions(const Napi::CallbackInfo& info) {
+  const Napi::Env env = info.Env();
+  if (info.Length() != 3 || !info[0].IsString() || !info[1].IsNumber() ||
+      !info[2].IsBoolean()) {
+    Napi::TypeError::New(
+        env,
+        "extractJsonWithOptions expects (filePath: string, viewMode: number, enableSidecars: boolean)")
+        .ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  const std::string path = info[0].As<Napi::String>().Utf8Value();
+  const int32_t viewMode = info[1].As<Napi::Number>().Int32Value();
+  XiftyExtractOptions options{};
+  options.enable_sidecars = info[2].As<Napi::Boolean>().Value();
+
+  const XiftyResult result = xifty_extract_json_with_options(
+      path.c_str(), static_cast<XiftyViewMode>(viewMode), options);
+
+  if (result.status != XIFTY_STATUS_CODE_SUCCESS) {
+    ThrowFromResult(env, result);
+    FreeResult(result);
+    return env.Null();
+  }
+
+  const std::string json = BufferToString(result.output);
+  FreeResult(result);
+  return Napi::String::New(env, json);
+}
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("version", Napi::Function::New(env, Version));
   exports.Set("probeJson", Napi::Function::New(env, ProbeJson));
   exports.Set("extractJson", Napi::Function::New(env, ExtractJson));
+  exports.Set("extractJsonWithOptions",
+              Napi::Function::New(env, ExtractJsonWithOptions));
   return exports;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,26 @@ import nodeGypBuild from "node-gyp-build";
 
 export type ViewName = "full" | "raw" | "interpreted" | "normalized" | "report";
 
+/**
+ * Sidecar discovery options.
+ *
+ * When `discoverFrom` is set, XIFty looks for co-located metadata sidecars
+ * (e.g. Sony NRT XML siblings of XAVC `.MP4` clips) and merges fields under
+ * `sources[].namespace = "<adapter_name>"` provenance. The path is the absolute
+ * on-disk path to the primary file — XIFty walks its siblings (and bounded
+ * parent directories where adapters require) to locate sidecars.
+ *
+ * Without `discoverFrom` the option is a no-op (matches behavior of the
+ * legacy `extract` API). Buffer-only callers always see no behavior change.
+ */
+export interface SidecarOptions {
+  discoverFrom?: string;
+  accept?: string[];
+}
+
 export interface ExtractOptions {
   view?: ViewName | number;
+  sidecars?: SidecarOptions;
 }
 
 export interface InputSummary {
@@ -73,6 +91,11 @@ interface NativeBinding {
   version(): string;
   probeJson(filePath: string): string;
   extractJson(filePath: string, viewMode: number): string;
+  extractJsonWithOptions(
+    filePath: string,
+    viewMode: number,
+    enableSidecars: boolean,
+  ): string;
 }
 
 const packageRoot = path.resolve(__dirname, "..");
@@ -130,6 +153,19 @@ export function extract(filePath: string, options: ExtractOptions = {}): XiftyEn
   const viewMode = typeof view === "number" ? view : viewByName[String(view) as ViewName];
   if (viewMode === undefined) {
     throw new TypeError(`unsupported view: ${view}`);
+  }
+  // Sidecar discovery requires an on-disk path. When `discoverFrom` is set we
+  // route through extractJsonWithOptions; otherwise we keep the legacy path so
+  // existing consumers see zero behavior change. The native side runs sidecar
+  // adapters relative to `filePath`, so callers should pass the same absolute
+  // path they want sidecars discovered from. The optional `discoverFrom` exists
+  // for forward compatibility (e.g. piped buffers backed by a real on-disk
+  // location) but today XIFty's discovery always uses the primary `filePath`.
+  const enableSidecars = options.sidecars?.discoverFrom != null;
+  if (enableSidecars) {
+    return JSON.parse(
+      native.extractJsonWithOptions(filePath, viewMode, true),
+    ) as XiftyEnvelope;
   }
   return JSON.parse(native.extractJson(filePath, viewMode)) as XiftyEnvelope;
 }


### PR DESCRIPTION
Closes #23.

Wires the new XIFty core sidecar surface (`xifty_extract_json_with_options`, shipped in core v0.1.13) through the Node binding and adds a sidecar-aware verification path to the release smoke harness.

## Why this is three pieces, not one

Original #23 framed this as a smoke-script extension. After looking at `src/addon.cc` it became clear that the published 0.1.16 binding doesn't expose the new FFI surface at all — `extractJson` only calls the legacy `xifty_extract_json`. So a smoke-script extension alone has no API to call. Real scope is binding work + TS surface + smoke harness, all in this PR. Issue body updated with the corrected scope.

## Surface changes

- **src/addon.cc:** new `extractJsonWithOptions(path, viewMode, enableSidecars)` N-API binding that calls `xifty_extract_json_with_options` with a `XiftyExtractOptions { enable_sidecars }` struct. Existing `extractJson` binding is unchanged for ABI/behavior stability.
- **src/index.ts:** `ExtractOptions` gains optional `sidecars: { discoverFrom?: string; accept?: string[] }`. When `discoverFrom` is set, `extract()` routes through `extractJsonWithOptions` with `enable_sidecars=true`. Without the option set, `extract()` continues to call the legacy path — zero behavior change for existing consumers.

## Smoke harness

- **scripts/smoke-packed-package.js:** new optional sidecar-aware path gated on `XIFTY_SMOKE_SIDECAR_FIELDS`. Asserts each named field surfaces with `sources[].namespace` matching `XIFTY_SMOKE_SIDECAR_NAMESPACE` (default `sony_nrt`). Existing smoke flow unchanged when the env var is unset.

## Verified locally

End-to-end against `fixtures/local/C0242.MP4` (Sony ZV-E10 XAVC clip) + sibling `C0242M01.XML`:

\`\`\`
packed package smoke passed for C0242.MP4 with video.bitrate, audio.sample_rate
packed package sidecar smoke passed for C0242.MP4 with umid, recording.mode, recording.capture_fps, timecode.ltc.start, device.serial_no (namespace=sony_nrt)
\`\`\`

All 5 named sidecar fields surface with the correct `sony_nrt` namespace from the rebuilt prebuilds.

## Release note

Will ship as @xifty/xifty 0.1.17. Bundling with XIFty core #128/#129 polish PR (already in flight as XIFty PR #130) for one richer release rather than three patches in 24h.